### PR TITLE
lineage: qcom: Enable media extensions for all QC devices

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -54,6 +54,9 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
         endif
     endif
 
+    # Enable media extensions
+    TARGET_USES_MEDIA_EXTENSIONS := true
+
     # Allow building audio encoders
     TARGET_USES_QCOM_MM_AUDIO := true
 


### PR DESCRIPTION
* This is now needed for the latest legacy HAL1 hacks, which were
  previously the only devices not using media extensions.
* Enable it for all QC devices to avoid running into
  issues with devices not having this enabled in the future.

Change-Id: I484840e712f7da6d0064a5f8016e8061b9cba838